### PR TITLE
Adding retroactive registration of non-csr enabled smart contracts

### DIFF
--- a/CIP-001.md
+++ b/CIP-001.md
@@ -19,12 +19,12 @@ We present a novel economic mechanism which modifies EIP-1559 to distribute a po
 # Specification
 The Accountant exists on the protocol layer and should be implemented as a Cosmos SDK module. As these processes will be responsible for maintaining significant portions of the network state, it must be implemented on the consensus-layer.  
 
-On the application layer, the CSR program functions as a series of smart contracts responsible for generating and maintaining a registry of eligible contract addresses. As a contract creator, participation is on an opt-in basis. Should a contract creator choose to deploy a CSR enabled contract, they must integrate support for the CSR Turnstile, described in the section below. Upon deployment of a CSR enabled contract, the contract creator is minted a CSR NFT. This NFT acts as a claim ticket for all future fees accrued. 
+On the application layer, the CSR program functions as a series of smart contracts responsible for generating and maintaining a registry of eligible contract addresses. As a contract creator, participation is on an opt-in basis. Should a contract creator choose to deploy a CSR enabled contract, they must integrate support for the CSR Turnstile, described in the section below. Smart contract creators can retroactively register smart contracts that were deployed before this CIP was made available through a special deployment verification transaction to the CSR Turnstile. Users that write smart contracts following the factory pattern can enable automatic registration of smart contracts created through the factory via the CSR Turnstile. Upon deployment of a CSR enabled contract, the contract creator is minted a CSR NFT. This NFT acts as a claim ticket for all future fees accrued. 
 
 ## Turnstile
 `Turnstile.sol` is a smart contract that registers other smart contracts on behalf of Accountant.
 
-To opt-in to the CSR program and mint the CSR NFT, contract deployment transactions must call the `register` function on `Turnstile.sol` to append the newly deployed contract address to the Accountant’s registry.
+To opt-in to the CSR program and mint the CSR NFT, contract deployment transactions must call the `register` function on `Turnstile.sol` to append the newly deployed contract address to the Accountant’s registry. Users can have their smart contract deployed and registered on their behalf with the `deploy` method. For users that want to register smart contracts that were not initially CSR-enabled can call the `retroactiveRegister` function, supplied with information to verify that they did deploy the smart contract, to register the smart contract to a new or existing NFT.
 
 The register defaults to minting a new NFT as the `beneficiary` and sending that NFT to `fromAddr`, but the function can be called to assign an existing NFT as the beneficiary or send newly minted NFT to another address.
 
@@ -57,6 +57,9 @@ turnstile.register in their deployment transaction.
 
 deploy contract onchain
 call turnstile.register(nftID, nftRecipient)
+
+# retroactiveRegister allows users to register non-csr enabled smart contracts in the Accountant
+turnstile.retroactiveRegister(contract, deployer, nonces, salt, nftID)
 
 
 ```


### PR DESCRIPTION
## Spec Update
In this PR, I add additional information to the spec which elaborates on the fact that users can follow the smart contract factory pattern to automatically register and deploy smart contracts. Additionally, I add a bit of info on functionality which will enable users to retroactively register their non-csr enable smart contracts.

### Retroactive Registration of Non-CSR Enabled Smart Contracts
In the current spec, smart contracts must inject turnstile code to extract transaction revenue. The turnstile currently allows users to deploy/register new smart contracts, however, when this CIP becomes available we also likely want to allow users to register smart contracts that were already deployed.

As such, we can do so by adding another function on the turnstile which accepts the smart contract they want to register and additional information which will be used to derive whether or not they deployed the smart contract. I believe that this is relatively important as the Canto dApp community will likely have difficulties migrating to new smart contracts. Additionally, this makes the CIP a little more extensible and versatile for users in general.